### PR TITLE
fix: don't wait for async method that send relocalization request

### DIFF
--- a/Assets/SolAR/Scripts/SolARCloudHololens2Specific.cs
+++ b/Assets/SolAR/Scripts/SolARCloudHololens2Specific.cs
@@ -294,9 +294,9 @@ namespace Com.Bcom.Solar
                     throw new ArgumentException($"Unkown sensor type: '{sensorType}'");
             }
 
-            if (!res) { Debug.LogError("Services not started"); ; OnSensorStarted?.Invoke(false); return; }
+            if (!res) { Log(LogLevel.ERROR, "Services not started"); OnSensorStarted?.Invoke(false); return; }
 
-            Debug.Log("Services started");
+            Log(LogLevel.INFO, "Services started");
 
             try
             {
@@ -306,7 +306,7 @@ namespace Com.Bcom.Solar
             }
             catch (Exception e)
             {
-                Debug.LogError($"Failed to start sensors: {e.Message}");
+                Log(LogLevel.ERROR, $"Failed to start sensors: {e.Message}");
                 OnSensorStarted?.Invoke(false); return;
             }
 
@@ -346,17 +346,20 @@ namespace Com.Bcom.Solar
 		        researchMode.Update();
 #endif
 
-                switch (sensorType)
-                {
-                    case Hl2SensorType.STEREO:
-                        await solARCloud.OnFrameReceived(GetLeftFrontVlcFrame(), GetRighFrontFrontVlcFrame()); break;
-                    case Hl2SensorType.RM_LEFT_FRONT:
-                        await solARCloud.OnFrameReceived(GetLeftFrontVlcFrame()); break;
-                    case Hl2SensorType.PV:
-                        await solARCloud.OnFrameReceived(getPvFrame()); break;
-                    default:
-                        throw new ArgumentException($"Unkown sensor type: '{sensorType}'");
-                }
+// Disable this warning: we want to use our "slots" mechanism to handle multiple simultaneous connections
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                    switch (sensorType)
+                    {
+                        case Hl2SensorType.STEREO:
+                            solARCloud.OnFrameReceived(GetLeftFrontVlcFrame(), GetRighFrontFrontVlcFrame()); break;
+                        case Hl2SensorType.RM_LEFT_FRONT:
+                            solARCloud.OnFrameReceived(GetLeftFrontVlcFrame()); break;
+                        case Hl2SensorType.PV:
+                            solARCloud.OnFrameReceived(getPvFrame()); break;
+                        default:
+                            throw new ArgumentException($"Unkown sensor type: '{sensorType}'");
+                    }
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             }
         }
 


### PR DESCRIPTION
If waited for, the slot mecanism is useless, and frame sendi is basically sequential and not parallelized at all.

This gives a significant FPS increase.